### PR TITLE
ci: add stability and packaging gates

### DIFF
--- a/.github/workflows/_quality.yaml
+++ b/.github/workflows/_quality.yaml
@@ -3,7 +3,12 @@ name: Quality
 on:
   workflow_call:
   pull_request:
-    branches: [ master ]
+    branches: [master]
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
 
 jobs:
   pre-commit:
@@ -12,42 +17,127 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
-      - uses: pre-commit/action@v3.0.0
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()
+          python-version: "3.10"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - run: uv sync --locked --no-default-groups --group format
+      - run: uv run --locked --no-default-groups --group format pre-commit run --all-files
 
-  test:
+  core-tests:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Cache virtualenv
-        uses: actions/cache@v3
-        id: virtualenv-cache
+      - uses: astral-sh/setup-uv@v6
         with:
-          path: |
-            ~/.cache
-          key: virtualenv-Python${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
-          restore-keys: |
-            virtualenv-Python${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
+          enable-cache: true
+      - run: uv sync --python ${{ matrix.python-version }} --locked --no-default-groups --group test
+      - run: uv run --python ${{ matrix.python-version }} --locked --no-default-groups --group test pytest
+      - run: uv pip check --python .venv
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
+  all-extras:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - run: uv sync --python 3.14 --locked --all-extras --no-default-groups --group test-all
+      - run: uv run --python 3.14 --locked --all-extras --no-default-groups --group test-all pytest --cov=eyepy
+      - name: Verify heavyweight optional dependency
+        run: uv run --python 3.14 --locked --all-extras --no-default-groups --group test-all python -c "import itk"
 
-      - name: Install Dependencies
-        if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-        run: uv sync --all-groups --all-extras
+  lowest-direct:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Resolve declared minimum direct dependencies
+        run: uv sync --python 3.10 --resolution lowest-direct --all-extras --no-default-groups --group test-all
+      - run: uv run --python 3.10 --frozen --all-extras --no-default-groups --group test-all pytest
+      - run: uv pip check --python .venv
 
-      - name: Test with pytest
-        run: uv run pytest --cov .
+  cross-platform-smoke:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - run: uv sync --python 3.14 --locked --no-default-groups --group test
+      - name: Smoke-test imports and representative file I/O
+        run: >-
+          uv run --python 3.14 --locked --no-default-groups --group test pytest
+          tests/test_io_heyex_vol.py
+          tests/test_io_heyex_xml.py
+          tests/test_eyevolume.py::test_save_load
+      - run: uv pip check --python .venv
+
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - run: uv sync --locked --no-default-groups --group doc
+      - run: uv run --locked --no-default-groups --group doc mkdocs build --strict
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/dependency-review-action@v4
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - run: uv lock --check
+      - run: uv build
+      - name: Install wheel in a clean environment
+        run: |
+          uv venv .wheel-venv
+          uv pip install --python .wheel-venv/bin/python ./dist/*.whl
+          uv pip check --python .wheel-venv/bin/python
+          .wheel-venv/bin/python -c "import eyepy; import eyepy.io.he.e2e_format"
+      - name: Verify wheel metadata
+        run: |
+          python - <<'PY'
+          import email
+          from pathlib import Path
+          import zipfile
+
+          wheel = next(Path('dist').glob('*.whl'))
+          with zipfile.ZipFile(wheel) as archive:
+              metadata_name = next(name for name in archive.namelist() if name.endswith('.dist-info/METADATA'))
+              metadata = email.message_from_bytes(archive.read(metadata_name))
+
+          assert metadata['Requires-Python'] == '<4.0,>=3.10'
+          PY

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   Quality:
-    uses: MedVisBonn/eyepy/.github/workflows/_quality.yaml@master
+    uses: ./.github/workflows/_quality.yaml
 
   release:
     needs: Quality
@@ -161,21 +161,9 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v6
         with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: ~/.cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install \
-              mkdocs-material \
-              mkdocstrings[python] \
-              mkdocs-gen-files \
-              mkdocs-literate-nav \
-              mkdocs-section-index \
-              pymdown-extensions \
-              mkdocs-macros-plugin \
-              eyepy[e2e]
-      - run: mkdocs gh-deploy --force
+          enable-cache: true
+      - run: uv sync --locked --no-default-groups --group doc
+      - run: uv run --locked --no-default-groups --group doc mkdocs gh-deploy --force

--- a/docs/gen_e2e_doc.py
+++ b/docs/gen_e2e_doc.py
@@ -22,7 +22,7 @@ def clean_docstring(docstring):
     :return: A cleaned version of the input docstring.
     """
     # Remove leading and trailing whitespace
-    docstring = docstring.strip()
+    docstring = (docstring or '').strip()
 
     # Remove any leading comment characters (#) or whitespace from each line
     lines = [
@@ -42,9 +42,29 @@ def clean_docstring(docstring):
     return '\n'.join(lines)
 
 
+def _doc_parts(obj):
+    """Return stable docstring fields for an E2E structure."""
+    doc = clean_docstring(obj.__doc__)
+    lines = doc.splitlines()
+    title = lines[0] if lines else obj.__name__
+    size = next(
+        (line.removeprefix('Size:').strip() for line in lines
+         if line.startswith('Size:')),
+        'unknown',
+    )
+    notes = doc.partition('Notes:')[2].strip() if 'Notes:' in doc else ''
+    description = next(
+        (line for line in lines[1:]
+         if line and not line.startswith(('Size:', 'Notes:'))),
+        '',
+    )
+    return title, size, notes, description
+
+
 def _get_parses_to(type_annotation):
     """Convert type annotations to markdown links."""
-    if type_annotation.__name__ == 'List':
+    annotation_name = getattr(type_annotation, '__name__', str(type_annotation))
+    if annotation_name == 'List':
         for t in type_annotation.__args__:
             return f'List[{_get_parses_to(t)}]'
     if type_annotation in types:
@@ -52,7 +72,7 @@ def _get_parses_to(type_annotation):
     elif type_annotation in file_structures:
         return f'[{type_annotation.__name__}]({type_annotation.__name__}.md)'
 
-    return str(type_annotation.__name__)
+    return annotation_name
 
 
 # Collect types data for the overview pages
@@ -61,18 +81,12 @@ types_data = {}
 nav = mkdocs_gen_files.Nav()
 for t in types:
     # Extract information from the docstring
-    doc = clean_docstring(t.__doc__)
-    doc_title = doc.splitlines()[0]
+    doc_title, size, text, description = _doc_parts(t)
     t_id = int(t.__name__.lstrip('Type'))
     type_occ = [k for k, v in e2e_reader.type_occurence.items() if t_id in v]
     type_occ = [f'[{t}](../he_e2e_hierarchy/{t}.md)' for t in type_occ]
 
     type_occ = ', '.join(type_occ)
-    size = [
-        l.lstrip('Size: ') for l in doc.splitlines() if l.startswith('Size: ')
-    ][0]
-    text = doc.split('Notes:')[1]
-
     # Name of the documentation file
     doc_path = Path(f'{t.__name__}.md')
     # Path to the documentation file
@@ -85,7 +99,7 @@ for t in types:
     types_data[t_id] = {
         'size': size,
         'content': doc_title,
-        'description': doc.splitlines()[1],
+        'description': description,
     }
 
     with mkdocs_gen_files.open(full_doc_path, 'w') as fd:
@@ -101,7 +115,7 @@ for t in types:
             description = f.metadata['subcon'].docs
             try:
                 size = f.metadata['subcon'].sizeof()
-            except:
+            except Exception:
                 size = 'variable'
             t_annotation = type_annotations[name]
             parses_to = _get_parses_to(t_annotation)
@@ -119,12 +133,7 @@ with mkdocs_gen_files.open('formats/he_e2e_types/SUMMARY.md', 'w') as nav_file:
 nav = mkdocs_gen_files.Nav()
 for t in file_structures:
     # Extract information from the docstring
-    doc = clean_docstring(t.__doc__)
-    doc_title = doc.splitlines()[0]
-    size = [
-        l.lstrip('Size: ') for l in doc.splitlines() if l.startswith('Size: ')
-    ][0]
-    text = doc.split('Notes:')[1]
+    doc_title, size, text, _ = _doc_parts(t)
 
     # Name of the documentation file
     doc_path = Path(f'{t.__name__}.md')
@@ -144,7 +153,7 @@ for t in file_structures:
             description = f.metadata['subcon'].docs
             try:
                 size = f.metadata['subcon'].sizeof()
-            except:
+            except Exception:
                 size = 'variable'
             t_annotation = type_annotations[name]
             parses_to = _get_parses_to(t_annotation)
@@ -179,7 +188,7 @@ for layer, types in e2e_reader.type_occurence.items():
                 content = types_data[t]['content']
                 size = types_data[t]['size']
                 description = types_data[t]['description'].strip('\n')
-            except:
+            except (KeyError, AttributeError):
                 content = ''
                 size = ''
                 description = ''
@@ -190,7 +199,7 @@ for layer, types in e2e_reader.type_occurence.items():
             else:
                 # Create a link to the type documentation
                 print(
-                    f'|[{t} :material-link:](../../../formats/he_e2e_types/Type{t}/)|{content}|{size}|{description}|',
+                    f'|[{t} :material-link:](../he_e2e_types/Type{t}.md)|{content}|{size}|{description}|',
                     file=fd)
 
 with mkdocs_gen_files.open('formats/he_e2e_hierarchy/SUMMARY.md',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ Repository = "https://github.com/MedVisBonn/eyepy"
 test = [
     "pytest>=8.0.0,<9",
     "pytest-cov>=6.0.0,<7",
+]
+test-all = [
+    {include-group = "test"},
     "imagecodecs>=2025.3.30",
     "scipy>=1.10.0",
     "matplotlib>=3.9.4",
@@ -91,7 +94,7 @@ notebook = [
     "jupyter>=1.0.0,<2",
 ]
 dev = [
-    {include-group = "test"},
+    {include-group = "test-all"},
     {include-group = "doc"},
     {include-group = "format"},
     {include-group = "notebook"},
@@ -135,7 +138,14 @@ wrap-summaries = 82
 blank = false
 
 [tool.pytest.ini_options]
-addopts = ["--import-mode=importlib"]
+addopts = ["--import-mode=importlib", "--strict-markers"]
+
+[tool.coverage.run]
+source = ["eyepy"]
+
+[tool.coverage.report]
+fail_under = 55
+skip_empty = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/eyepy/core/annotations.py
+++ b/src/eyepy/core/annotations.py
@@ -240,7 +240,7 @@ class PolygonAnnotation:
         return self.__class__(result, shape=self._shape)
 
     def plot(self, ax: Axes | None = None, offset: tuple[float, float] = (0, 0),
-             **kwargs) -> None:
+             **kwargs: Any) -> None:
         """Plot the polygon outline on the given axes.
 
         Args:
@@ -1400,7 +1400,7 @@ class EyeEnfaceOpticDiscAnnotation(PolygonAnnotation):
              plot_contour: bool = True, plot_area: bool = False,
              contour_color: str = 'red', contour_linewidth: float = 2,
              contour_linestyle: str = '-', area_color: str | None = None,
-             area_alpha: float = 0.3, **kwargs) -> None:
+             area_alpha: float = 0.3, **kwargs: Any) -> None:
         """Plot the optic disc annotation on the given axes.
 
         Provides flexible visualization options including contour outline and/or filled area.
@@ -1502,7 +1502,7 @@ class EyeEnfaceFoveaAnnotation(PolygonAnnotation):
 
     def plot(self, ax: plt.Axes | None = None, offset: tuple[float, float] = (0, 0),
              color: str = 'yellow', marker: str = '+', markersize: float = 12,
-             markeredgewidth: float = 2, **kwargs) -> None:
+             markeredgewidth: float = 2, **kwargs: Any) -> None:
         """Plot the fovea annotation on the given axes as a center marker.
 
         Args:

--- a/src/eyepy/quant/regions.py
+++ b/src/eyepy/quant/regions.py
@@ -231,7 +231,7 @@ class RegionQuantification:
         scale_x: float = 1.0,
         scale_y: float = 1.0,
         unit: str = 'px',
-    ):
+    ) -> RegionQuantification:
         """Quantify region from a binary mask with custom origin.
 
         Computes directional extent (midpoint) and arc statistics in all 8 directions (temporal, nasal,
@@ -279,7 +279,7 @@ class RegionQuantification:
         scale_y: float = 1.0,
         origin_mode: OriginModeType = OriginMode.HYBRID,
         unit: str = 'px',
-    ):
+    ) -> RegionQuantification:
         """Quantify region from a binary mask.
 
         Computes directional extent (midpoint) and arc statistics in all 8 directions (temporal, nasal,
@@ -370,7 +370,7 @@ class RegionQuantification:
         area_map_name: str,
         origin_mode: OriginModeType = OriginMode.HYBRID,
         custom_origin: Optional[AnatomicalOrigin] = None,
-    ):
+    ) -> RegionQuantification:
         """Create RegionQuantification from an EyeEnface object.
 
         A RegionQuantification quantifies an annotation mask of one connected component.

--- a/tests/test_quantification_kwargs.py
+++ b/tests/test_quantification_kwargs.py
@@ -2,9 +2,10 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+
+plt = pytest.importorskip('matplotlib.pyplot')
 
 import eyepy as ep
 

--- a/uv.lock
+++ b/uv.lock
@@ -954,6 +954,10 @@ notebook = [
     { name = "jupyter" },
 ]
 test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+test-all = [
     { name = "imagecodecs", version = "2025.3.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "imagecodecs", version = "2026.3.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "imagecodecs", version = "2026.6.26", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -1037,6 +1041,10 @@ format = [
 ]
 notebook = [{ name = "jupyter", specifier = ">=1.0.0,<2" }]
 test = [
+    { name = "pytest", specifier = ">=8.0.0,<9" },
+    { name = "pytest-cov", specifier = ">=6.0.0,<7" },
+]
+test-all = [
     { name = "imagecodecs", specifier = ">=2025.3.30" },
     { name = "itk", specifier = ">=5.3.0,<6" },
     { name = "matplotlib", specifier = ">=3.9.4" },


### PR DESCRIPTION
## Summary
- add Linux Python 3.10-3.14 core tests, Linux all-extras coverage, Python 3.14 Windows/macOS file-I/O smoke tests, and lowest-direct validation
- add lock, strict documentation, clean-wheel import, metadata, and dependency-consistency gates
- keep a 55% coverage floor and make non-release artifact/docs jobs skip cleanly
- harden the E2E docs generator and optional plotting test so the new core/docs lanes are truthful

## Local validation
- core: 197 passed, 3 skipped on Python 3.14
- all extras: 210 passed; 55.32% coverage
- lowest direct: 210 passed on Python 3.10
- mkdocs build --strict: passed
- wheel build/import/metadata: passed
- pre-commit: passed
- uv lock --check: passed