### PR TITLE
fix(e2e): migrate to construct-typing 0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy>=1.22.0",
     "scikit-image>=0.22.0",
     "construct>=2.10.68",
-    "construct-typing>=0.7.0,<0.8",
+    "construct-typing>=0.8.1,<0.9",
     "imageio>=2.25.1,<3",
 ]
 

--- a/src/eyepy/io/he/e2e_format.py
+++ b/src/eyepy/io/he/e2e_format.py
@@ -5,6 +5,7 @@ import typing as t
 
 import construct as cs
 from construct_typed import csfield
+from construct_typed import csfield_noinit
 from construct_typed import DataclassMixin
 from construct_typed import DataclassStruct
 from construct_typed import EnumBase
@@ -823,7 +824,7 @@ class Chunk(DataclassMixin):
         doc=
         'In the data we have seen each chunk has 512 folders with headers of size 44'
     )
-    jump: int = csfield(
+    jump: int | None = csfield_noinit(
         cs.Seek(cs.this.folders[-1].start + cs.this.folders[-1].size +
                 datacontainer_format.header.sizeof()))
 

--- a/tests/test_e2e_format.py
+++ b/tests/test_e2e_format.py
@@ -15,6 +15,21 @@ def test_e2e_structures_import_with_supported_construct_typing():
     assert chunk_format is not None
 
 
+def test_chunk_seek_field_parses_without_becoming_an_init_argument():
+    """Seek-only fields remain parseable with construct-typing 0.8."""
+    header = struct.pack(
+        '<12sI10HIIII', b'CHUNK', 1, *([0] * 10), 1, 0, 0, 0
+    )
+    folder = struct.pack(
+        '<IIIIiiiiHHII', 0, 96, 0, 0, 1, 2, 3, 4, 1, 0, 9, 0
+    )
+
+    parsed = chunk_format.parse(header + folder + bytes(60))
+
+    assert len(parsed.folders) == 1
+    assert parsed.folders[0].type.name == 'patient'
+
+
 def _type9_container(firstname, surname, patient_id):
     item = (
         firstname.ljust(31, b'\x00')[:31] +

--- a/uv.lock
+++ b/uv.lock
@@ -453,15 +453,16 @@ wheels = [
 
 [[package]]
 name = "construct-typing"
-version = "0.7.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "arrow" },
     { name = "construct" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/ae/659fe4866d89ef5a3a65cddbdd7b35882f4feb72db383821965f2fcea934/construct_typing-0.7.0.tar.gz", hash = "sha256:71d110dedff39bd3b603c734077032a7065bc597a49db1f5b03a211d05dbac23", size = 45104, upload-time = "2025-10-27T19:30:29.614Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/de/de378332a7cb2f62df134e0b5915a0fea939219c80ecee99b29da8ba49c7/construct_typing-0.8.1.tar.gz", hash = "sha256:b3c33246b83f187f21fbfa9e229cf7225fe42823f3d598328b973c844071c456", size = 53118, upload-time = "2026-07-23T08:48:19.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/0c/2db6f7e1ae9795e436c6a0dc0bc38b12b8c8a228cb63203e24190b755b3b/construct_typing-0.7.0-py3-none-any.whl", hash = "sha256:c92383c6e8e5d07ba25811c8d5163820458d821e73bb1006541f43f89788646c", size = 24350, upload-time = "2025-10-27T19:30:27.505Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/7dd59e010765f5c0043a5cf59e0f3e6748cd966491645bbb10b88ad24c82/construct_typing-0.8.1-py3-none-any.whl", hash = "sha256:9b5845dbaf959c9d960f5105f9ab3533227c4da2b76baa57d1f1c0aa2a088cdb", size = 26727, upload-time = "2026-07-23T08:48:17.908Z" },
 ]
 
 [[package]]
@@ -987,7 +988,7 @@ test-all = [
 [package.metadata]
 requires-dist = [
     { name = "construct", specifier = ">=2.10.68" },
-    { name = "construct-typing", specifier = ">=0.7.0,<0.8" },
+    { name = "construct-typing", specifier = ">=0.8.1,<0.9" },
     { name = "imagecodecs", marker = "extra == 'all'", specifier = ">=2025.3.30" },
     { name = "imagecodecs", marker = "extra == 'tiff'", specifier = ">=2025.3.30" },
     { name = "imageio", specifier = ">=2.25.1,<3" },


### PR DESCRIPTION
## Summary
- require construct-typing 0.8.1 through the compatible 0.8 series
- migrate the seek-only E2E chunk field to csfield_noinit
- add deterministic synthetic chunk parsing coverage

## Validation
- 13 focused E2E, VOL, XML, and backward-compatibility tests pass
- complete all-extras suite: 215 passed on Python 3.14
- coverage 59.89% (floor 55%)
- lock and commit-time checks pass