### PR TITLE
fix: preserve final local cleanup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ angio_ev = load("healthy_OD_Angio")
 If you have data at hand use one of eyepy's import functions.
 
 ```python
+import eyepy as ep
+
 # Import HEYEX E2E export
 ev = ep.import_heyex_e2e("path/to/file.e2e")
 # Import HEYEX XML export

--- a/docs/formats/SUMMARY.md
+++ b/docs/formats/SUMMARY.md
@@ -1,7 +1,9 @@
 * [Heidelberg E2E](he_e2e.md)
     * [E2E File Structures](he_e2e_structures/he_e2e_structure_doc.md)
         * he_e2e_structures/*md
-    * [E2E Types](he_e2e_types/)
-    * [E2E Hierarchy](he_e2e_hierarchy/)
+    * E2E Types
+        * he_e2e_types/*md
+    * E2E Hierarchy
+        * he_e2e_hierarchy/*md
 * [Heidelberg VOL](he_vol.md)
 * [Heidelberg XML](he_xml.md)

--- a/tests/test_spatial_quantification.py
+++ b/tests/test_spatial_quantification.py
@@ -448,7 +448,9 @@ class TestEdgeCases:
         extent = polar_ref.compute_directional_extent(mask)
         # Should not crash and should return valid ExtentMetrics
         assert isinstance(extent, DirectionalExtent)
-        assert extent.temporal.midpoint >= 0  # Single pixel may have 0 extent    def test_asymmetric_region(self):
+        assert extent.temporal.midpoint >= 0  # Single pixel may have 0 extent
+
+    def test_asymmetric_region(self):
         """Test that asymmetric regions have different directional extents."""
         origin = AnatomicalOrigin.from_optic_disc(
             optic_disc_center=(50.0, 50.0),


### PR DESCRIPTION
## Summary
- define the eyepy alias used by the README import examples
- include generated E2E type and hierarchy pages directly in literate navigation
- restore the asymmetric-region test as an independently collected test

## Validation
- 25 spatial quantification tests pass
- test_asymmetric_region is collected independently
- mkdocs build --strict passes without the two E2E directory-link warnings
- pre-commit passes