### PR TITLE
fix(ci): install uv for semantic release build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ upload_to_pypi = true
 upload_to_vsc_release = true
 # Use uv to build distributions (includes hatchling backend)
 build_command = """
+    python -m pip install --disable-pip-version-check "uv==0.9.6"
     uv lock --upgrade-package "$PACKAGE_NAME"
     git add uv.lock
     uv build


### PR DESCRIPTION
## Cause
python-semantic-release runs its build command inside a Docker container that does not include uv, so the 0.21.0 release aborted before creating a commit, tag, or release.

## Fix
- install pinned uv 0.9.6 inside the semantic-release environment before invoking the configured lock and build commands

## Validation
- installed uv 0.9.6 with pip in an isolated Python 3.14 environment
- uv lock --check passes
- uv 0.9.6 builds the wheel and sdist
- pre-commit passes

Merging this PR triggers a fresh semantic-release attempt for 0.21.0.